### PR TITLE
Revert "MAX-32464 Add log to check cost not report issue on zinc related instance"

### DIFF
--- a/libs/community/langchain_community/callbacks/openai_info.py
+++ b/libs/community/langchain_community/callbacks/openai_info.py
@@ -189,16 +189,12 @@ class OpenAICallbackHandler(BaseCallbackHandler):
         completion_tokens = token_usage.get("completion_tokens", 0)
         prompt_tokens = token_usage.get("prompt_tokens", 0)
         model_name = standardize_model_name(response.llm_output.get("model_name", ""))
-        # TODO Remove the following test log
-        print(f"Report metrics cost issue check: {model_name}, {response.llm_output.get('model_name', '')}, {model_name in MODEL_COST_PER_1K_TOKENS}") # noqa: E501
         if model_name in MODEL_COST_PER_1K_TOKENS:
             completion_cost = get_openai_token_cost_for_model(
                 model_name, completion_tokens, is_completion=True
             )
             prompt_cost = get_openai_token_cost_for_model(model_name, prompt_tokens)
             self.total_cost += prompt_cost + completion_cost
-            # TODO Remove the following test log
-            print(f"Report metrics cost issue check: completion_cost {completion_cost}, prompt_cost {prompt_cost}, total_cost {self.total_cost}") # noqa: E501
         self.total_tokens += token_usage.get("total_tokens", 0)
         self.prompt_tokens += prompt_tokens
         self.completion_tokens += completion_tokens


### PR DESCRIPTION
Reverts ServiceMax-Engineering/langchain#2

The cost not calculate issue already fixed by https://github.com/ServiceMax-Engineering/help-doc-ai/pull/184, just revert to remove the log.

@shinxi, please help review.